### PR TITLE
Logo resized on page, top padding removed in css

### DIFF
--- a/app/assets/stylesheets/body.scss
+++ b/app/assets/stylesheets/body.scss
@@ -13,3 +13,7 @@
   color: #556F7A;
   text-align: center;
 }
+
+.logo {
+  padding-top: 0;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <%= link_to image_tag("bricks-logo.gif", size: "95x73"), root_path, class: "navbar-brand" %>
+        <%= link_to image_tag("bricks-logo.gif", size: "70x50"), root_path, class: "logo navbar-brand" %>
       </div>
       <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">


### PR DESCRIPTION
Hey all, 

Brickhaus logo was resized to fit inside the header.
