### PR TITLE
Associating agents and houses

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -73,7 +73,7 @@ class HomesController < ApplicationController
 
   # Only allow a trusted parameter "white list" through.
   def home_params
-    params.require(:home).permit(:main_image, :additional_image, :address, :beds, :baths, :square_footage, :price, :description, agent: [:id ], links_attributes: [ :url, :description ])
+    params.require(:home).permit(:main_image, :additional_image, :address, :beds, :baths, :square_footage, :price, :description, :agent_id, links_attributes: [ :url, :description ])
   end
 
   def build_response_to_search_params(params)

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -16,12 +16,17 @@ class HomesController < ApplicationController
 
   # GET /homes/new
   def new
+    @agents = User.where('is_agent = true')
     @home = Home.new
   end
 
   # GET /homes/1/edit
   def edit
-    redirect_to homes_path unless @home.user_authorized?(current_user)
+    @agents = User.where('is_agent = true')
+    unless @home.user_authorized?(current_user)
+      flash[:notice] = 'Only the home owner may edit the home'
+      redirect_to homes_path
+    end
   end
 
   # POST /homes

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -43,7 +43,10 @@ class HomesController < ApplicationController
 
   # PATCH/PUT /homes/1
   def update
-    redirect_to homes_path unless @home.user_authorized?(current_user)
+    unless @home.user_authorized?(current_user)
+      flash[:notice] = 'Only the home owner may edit the home'
+      redirect_to homes_path
+    end
 
     if @home.update(home_params)
       redirect_to @home, notice: 'Home was successfully updated.'
@@ -54,7 +57,10 @@ class HomesController < ApplicationController
 
   # DELETE /homes/1
   def destroy
-    redirect_to homes_path unless @home.user_authorized?(current_user)
+    unless @home.user_authorized?(current_user)
+      flash[:notice] = 'Only the home owner may edit the home'
+      redirect_to homes_path
+    end
 
     @home.delete
     redirect_to homes_url, notice: 'Home was successfully destroyed.'
@@ -67,7 +73,7 @@ class HomesController < ApplicationController
 
   # Only allow a trusted parameter "white list" through.
   def home_params
-    params.require(:home).permit(:main_image, :additional_image, :address, :beds, :baths, :square_footage, :price, :description, links_attributes: [ :url, :description ])
+    params.require(:home).permit(:main_image, :additional_image, :address, :beds, :baths, :square_footage, :price, :description, agent: [:id ], links_attributes: [ :url, :description ])
   end
 
   def build_response_to_search_params(params)

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -16,13 +16,13 @@ class HomesController < ApplicationController
 
   # GET /homes/new
   def new
-    @agents = User.where('is_agent = true')
+    @agents = User.agents
     @home = Home.new
   end
 
   # GET /homes/1/edit
   def edit
-    @agents = User.where('is_agent = true')
+    @agents = User.agents
     unless @home.user_authorized?(current_user)
       flash[:notice] = 'Only the home owner may edit the home'
       redirect_to homes_path

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,6 +1,6 @@
 class RegistrationsController < Devise::RegistrationsController
   def index
-    @users = User.where('is_agent = true')
+    @users = User.agents
   end
 
   def show

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -1,11 +1,9 @@
 class Home < ApplicationRecord
   belongs_to :agent, class_name: "User", optional: true
   belongs_to :owner, class_name: "User", optional: true
-  has_many :links
+  has_many :links, dependent: :destroy
 
-  accepts_nested_attributes_for :links,
-                                allow_destroy: true,
-                                reject_if: :all_blank
+  accepts_nested_attributes_for :links, allow_destroy: true, reject_if: :all_blank
 
   # Refile home image
   attachment :main_image

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,7 @@ class User < ApplicationRecord
 
   # Refile profile image for agents
   attachment :profile_image
+
+  # Adding a scope for agents
+  scope :agents, -> { where(is_agent: true)}
 end

--- a/app/views/homes/_form.html.erb
+++ b/app/views/homes/_form.html.erb
@@ -70,7 +70,10 @@
   </div>
 
   <div class="form-group">
-    <%= collection_select(:home, :agent_id, @agents, :id, :name, {class: "form-control"}) %>
+    <%= f.label "Agent", class: "col-sm-2 control-label" %>
+    <div class="col-sm-10">
+      <%= collection_select(:home, :agent_id, @agents, :id, :name, {class: "form-control"}) %>
+    </div>
   </div>
 
 

--- a/app/views/homes/_form.html.erb
+++ b/app/views/homes/_form.html.erb
@@ -23,7 +23,7 @@
       <%= f.text_field :description, class: "form-control" %>
     </div>
   </div>
-  
+
   <div class="form-group field">
     <%= f.label "Main Image", class: "col-sm-2 control-label" %>
     <%= f.attachment_field :main_image %><br />
@@ -67,6 +67,10 @@
     <div class="col-sm-10">
       <%= f.number_field :price, class: "form-control" %>
     </div>
+  </div>
+
+  <div class="form-group">
+    <%= collection_select(:home, :agent_id, @agents, :id, :name, {class: "form-control"}) %>
   </div>
 
 

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -35,10 +35,16 @@
   <p><%= @home.description %></p>
 
         <% if @home.owner %>
-        <dt>Owner:</dt>
-        <dd><%= @home.owner.name %></dd>
-        <%else%>
-        <dt>associated agent</dt>
-        <dd>Agent's info to follow</dd>
+          <dt>Owner:</dt>
+          <dd><%= @home.owner.name %></dd>
         <% end %>
+
+        <% if @home.agent %>
+          <dt>Agent:</dt>
+          <dd><%= link_to @home.agent.name, show_profile_path(@home.agent) %></dd>
+        <%else%>
+          <dt>associated agent</dt>
+          <dd>Agent's info to follow</dd>
+        <% end %>
+
 </div>


### PR DESCRIPTION
Can now add an agent to a home from a dropdown list.  I also, perhaps in poor form, added notices to some authorization redirects unrelated to this issue.  The agent is now also displayed on the forms show as a link to the agent's profile

closes #8 
